### PR TITLE
docs: improve documentation clarity and organization

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.10"
+          - "1"
           - "lts"
           - "pre"
         os:

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,15 +37,28 @@ The following function derives directionally resolved flux spectra (omni, para, 
 epd_spectral("2020-10-01", "2020-10-02"; probe = "a")
 ```
 
-Commonly used variables have concise convenience wrappers. Because these variables are uniquely identified, no additional metadata (such as `probe`, `datatype`, `level`, or `dataset`) is required.
+Commonly used variables have concise convenience wrappers. Because these variables are uniquely named, no additional metadata (such as `probe`, `datatype`, `level`, or `dataset`) is required to access them.
 
 ```@example quick_start
 ELA_POS_GEI("2020-10-01", "2020-10-02")
+# Alternative ways to access the same variable: 
+# `STATE("2020-10-01", "2020-10-02"; probe = "a")["ela_pos_gei"]` or
+# `ELA_L1_STATE("2020-10-01", "2020-10-02")["ela_pos_gei"]`
+
 ELB_FGS("2020-10-01", "2020-10-02")
+# Alternative ways to access the same variable: 
+# `ELB_L1_FGS("2020-10-01", "2020-10-02")["elb_fgs"]` or 
+# `FGM("2020-10-01", "2020-10-02"; probe = "b", datatype = "survey")["elb_fgs"]`
+
 ELA_PEF_HS_EPAT_NFLUX("2020-10-01", "2020-10-02")
+# Alternative ways to access the same variable: 
+# `ELA_L2_EPDEF("2020-10-01", "2020-10-02")["ela_pef_hs_Epat_nflux"]` or 
+# `EPD("2020-10-01", "2020-10-02"; probe = "a", level = "l2", datatype = "epdef")["ela_pef_hs_Epat_nflux"]`
 ```
 
-## Instruments
+## API
+
+### Instruments
 
 ```@docs
 EPD
@@ -53,21 +66,21 @@ FGM
 STATE
 ```
 
-## Datasets
+### Datasets
 
 ```@autodocs
 Modules = [ELFINData]
 Filter = t -> t isa ELFINData.ELFINLogicalDataset
 ```
 
-## Variables
+### Variables
 
 ```@autodocs
 Modules = [ELFINData]
 Filter = t -> t isa ELFINData.ELFINLogicalVariable
 ```
 
-## API
+### Functions and Types
 
 ```@autodocs
 Modules = [ELFINData]
@@ -107,5 +120,4 @@ b2 = @b PySPEDAS.elfin.epd($trange; level = "l2")
 ```
 
 !!! note "Array layout"
-
-Julia arrays follow the column-major convention used by most CDF files (time is the last dimension), whereas NumPy and PySPEDAS use row-major arrays (time is the first dimension). Transpose the PySPEDAS output before comparing so the dimensions align.
+    Julia arrays follow the column-major convention used by most CDF files (time is the last dimension), whereas NumPy and PySPEDAS use row-major arrays (time is the first dimension). Transpose the PySPEDAS output before comparing so the dimensions align.

--- a/src/ELFINData.jl
+++ b/src/ELFINData.jl
@@ -24,6 +24,7 @@ using SpaceDataModel: AbstractInstrument, AbstractDataSet
 using Downloads: request
 using VelocityDistributionFunctions: directional_energy_spectra, PAspectra, sort_flux_by_pitch_angle!
 using Dates
+using URIs
 
 export ELA_L1_EPDEF, ELB_L1_EPDEF, ELA_L2_EPDEF, ELB_L2_EPDEF, ELA_L1_EPDIF, ELB_L1_EPDIF,
     ELA_PEF, ELB_PEF, ELA_PIF, ELB_PIF,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,3 @@
-import Base: read
-using URIs
-
 function format_date(pattern, date)
     return replace(
         pattern,
@@ -24,8 +21,6 @@ function RemoteFile(uri::URI; dir = ".", updates = :never, flatten = false)
 end
 
 RemoteFile(uri::String; kwargs...) = RemoteFile(URI(uri); kwargs...)
-
-local_path(f) = f.path
 
 function local_path(uri::URI, dir = "."; flatten::Bool = false)
     fullpath = lstrip(uri.path, '/')


### PR DESCRIPTION
- Expanded examples in quick start guide to show alternative ways to access variables
- Reorganized API documentation sections with clearer hierarchical structure
- Added explanatory comments for each code example to show equivalent access methods
- Fixed formatting of note block about array layout
- Cleaned up code organization in utils.jl by removing unused imports and functions
